### PR TITLE
fix/responsive homepage - Viewport Issue and Hero (#15)

### DIFF
--- a/src/context/index/hero/hero.css
+++ b/src/context/index/hero/hero.css
@@ -1,15 +1,23 @@
 .hero {
+    --margin-top: 0;
+    margin-top: var(--margin-top);
     min-height: 100vh;
     width: 100%;
     gap: 2rem;
     display: flex;
     overflow: hidden;
+    
 
-    @media (width < 768px) {
-        margin-top: 10rem;
+    @media (width < 1190px) {
+        --margin-top: 10rem;
+        margin-bottom: 5rem;
         flex-direction: column-reverse;
         min-height: 100dvh;
+        max-width: 800px;
         height: 100%;
+    }
+    @media (width < 625px) {
+        --margin-top: 5rem;
     }
 }
 
@@ -22,14 +30,17 @@
     height: auto;
     padding: 1rem;
     gap: 1rem;
+    line-height: 1.4;
 
-    @media (width < 768px) {
+    @media (width < 1190px) {
         align-items: center;
         text-align: center;
         gap: 4rem;
     }
 
+    
     & h1 {
+        line-height: 1.2;
         font-size: 4rem;
         background: -webkit-linear-gradient(rgb(224, 255, 253), var(--light-spot-color));
         background-clip: text;
@@ -37,18 +48,39 @@
         -webkit-text-fill-color: transparent;
         transition: all 0.5s ease-in-out;
     }
-
+    
     & p {
         font-size: 1.6rem;
         margin: 1rem 0;
         line-height: 1.6;
     }
-
+    
     .hero__button {
         min-width: 30rem;
         width: fit-content;
         background: var(--light-spot-color);
         box-shadow: 0 0 3px var(--light-spot-color);
+    }
+
+    @media (width < 625px) {
+        gap: 2rem;
+        & h1 {
+            font-size: 3rem;
+        }
+        & p {
+            font-size: 1.4rem;
+        }
+        & .hero__button {
+            min-width: 20rem;
+            min-height: 4rem;
+        }
+    }
+
+    @media (height < 850px) {
+        gap: 1.5rem;
+        & h1 {
+            font-size: 2.8rem;
+        }
     }
 }
 
@@ -63,17 +95,22 @@
 
 .hero__image {
     z-index: -1;
-    width: 300px;
-    height: 300px;
-    height: auto;
+    --icon-size: 300px;
+    width: var(--icon-size);
+    height: var(--icon-size);
+    /* height: auto; Removing this prevents layout shifts when switching icons*/
+    object-fit: contain;
     position: absolute;
     top: -23rem;
     object-fit: contain;
     position: absolute;
     filter: drop-shadow(0 0 9.3px var(--light-spot-color));
     transition: transform 0.5s ease-in-out, filter 2s ease-in-out;
-    @media (width < 768px) {
+    @media (width < 1190px) {
        position: static;
+    }
+    @media (height < 850px) {
+        --icon-size: 180px;
     }
 }
 

--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -12,7 +12,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 <meta charset="utf-8" />
 <link rel="icon" type="image/png" href="/favicon.png" />
-<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="width=device-width, minimum-scale=1.0" />
 <link rel="canonical" href={canonicalURL} />
 
 <title>{title}</title>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -49,7 +49,10 @@ import Footer from "@components/Footer.astro";
 <style is:inline>
   main{
     max-width: 1200px;
+    --main-padding-x: 0;
     padding-bottom: 3rem;
+    padding-left: var(--main-padding-x);
+    padding-right: var(--main-padding-x);
   }
   .button-base {
     background: linear-gradient(to top, rgb(51, 137, 235, 0.6), transparent);
@@ -70,6 +73,13 @@ import Footer from "@components/Footer.astro";
     display: inline-flex;
     @media (width < 768px) {
       display: none;
+    }
+  }
+
+  /* Media Query for Main */
+  @media (width < 940px) {
+    main {
+      --main-padding-x: 1rem;
     }
   }
 </style>


### PR DESCRIPTION
## Description 

### Viewport Horizontal Scaling and Scroll Issue
Added a minimum scale of 100% to the viewport meta element. This prevents the issue in the image below.
Before:
<img width="413" height="845" alt="image" src="https://github.com/user-attachments/assets/1a7515c3-2d72-4332-8f3e-103c665b5618" />

After:
<img width="800" height="1054" alt="image" src="https://github.com/user-attachments/assets/7410bce3-69c0-4ee4-ba85-c3e445b359d6" />

### Main Element Padding
Added horizontal padding to the main element on screen sizes below 940px, to prevent elements from touching the edges of the screen. 

### Hero Section Responsiveness
- Changed the first breakpoint to 1190px; found to work better with the layout change and to prevent overflow of the text.
- Adjusted typography based upon the breakpoints defined.
- Added a vertical breakpoint to adjust hero content gaps and icon sizing to make sure the button is visible in most smartphone screen sizes.

## Related Issue
#15 
- [x] No horizontal scrolling appears on any screen size

> **Note:** This is an initial partial solution intended to evaluate the approach before proceeding further.